### PR TITLE
eKermit: return to eKermit *cmlist functionality

### DIFF
--- a/kermitUefi.c
+++ b/kermitUefi.c
@@ -530,15 +530,7 @@ kermit(short f,				/* Function code */
 	    debug(DB_LOG,"Ebqflg",0,(k->ebqflg));
 	    debug(DB_CHR,"Ebq",0,(k->ebq));
 	}
-	//k->filename = *(k->filelist);	/* Get next filename */
-  EFI_STATUS efiStatus;
-  efiStatus = getNextFilename( &k->filename[0] ); 
-  if (EFI_ERROR(efiStatus)) {
-      debug(DB_LOG, "efiStatus", 0, efiStatus);
-  } else {
-      debug(DB_LOG, "getNextFilename", k->filename, 0 );
-      //AsciiPrint ( "getNextFilename %a %r", k->filename, efiStatus );
-  }
+	k->filename = *(k->filelist);	/* Get next filename */
 	if (k->filename) {		/* If there is one */
 	    //int i;
 	    for (i = 0; i < FN_MAX; i++) { /* Copy name to result struct */

--- a/platformUefi.h
+++ b/platformUefi.h
@@ -3,7 +3,7 @@
   The platform.h definitions for embedded Kermit v1.6 for use under Uefi as a
   Shell application.
 
-Portions Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+Uefi Portions Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 Portions Copyright (C) 1995, 2011, 
@@ -128,7 +128,5 @@ void * memset (void *, UINTN, UINT8);
 #define P_WSLOTS 1
 
 #define MAXRPKTLEN 63
-
-extern EFI_STATUS EFIAPI getNextFilename( UCHAR * );
 
 #endif //__KERMIT_PLATFORM_H__


### PR DESCRIPTION
Remove ugly getNextFilename hack from kermit.

Signed-off-by: Zitterkopf, John <Zittware@hotmail.com>